### PR TITLE
Update deprecated jsoncpp

### DIFF
--- a/tests/http_client_load_test.cpp
+++ b/tests/http_client_load_test.cpp
@@ -134,7 +134,6 @@ TEST_F(HttpClientLoadTest, async_head_request_for_existing_resource_succeeds)
     {
         // All endpoint data on httpbin.org is JSON encoded.
         json::Value root;
-        json::Reader reader;
 
         // We expect the query to complete successfully
         EXPECT_EQ(core::net::http::Status::ok, response.status);
@@ -159,12 +158,14 @@ TEST_F(HttpClientLoadTest, async_get_request_for_existing_resource_succeeds)
     {
         // All endpoint data on httpbin.org is JSON encoded.
         json::Value root;
-        json::Reader reader;
+        json::CharReaderBuilder b;
+        json::CharReader* reader(b.newCharReader());
+        std::string error;
 
         // We expect the query to complete successfully
         EXPECT_EQ(core::net::http::Status::ok, response.status);
         // Parsing the body of the response as JSON should succeed.
-        EXPECT_TRUE(reader.parse(response.body, root));
+        EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
         // The url field of the payload should equal the original url we requested.
         EXPECT_EQ(url, root["url"].asString());
 
@@ -191,12 +192,14 @@ TEST_F(HttpClientLoadTest, async_post_request_for_existing_resource_succeeds)
     {
         // All endpoint data on httpbin.org is JSON encoded.
         json::Value root;
-        json::Reader reader;
+        json::CharReaderBuilder b;
+        json::CharReader* reader(b.newCharReader());
+        std::string error;
 
         // We expect the query to complete successfully
         EXPECT_EQ(core::net::http::Status::ok, response.status);
         // Parsing the body of the response as JSON should succeed.
-        EXPECT_TRUE(reader.parse(response.body, root));
+        EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
         // The url field of the payload should equal the original url we requested.
         EXPECT_EQ(payload, root["data"].asString());
 

--- a/tests/http_client_test.cpp
+++ b/tests/http_client_test.cpp
@@ -144,7 +144,9 @@ TEST(HttpClient, get_request_for_existing_resource_succeeds)
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     // We finally execute the query synchronously and story the response.
     auto response = request->execute(default_progress_reporter);
@@ -152,7 +154,7 @@ TEST(HttpClient, get_request_for_existing_resource_succeeds)
     // We expect the query to complete successfully
     EXPECT_EQ(core::net::http::Status::ok, response.status);
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     // The url field of the payload should equal the original url we requested.
     EXPECT_EQ(url, root["url"].asString());
 }
@@ -174,7 +176,9 @@ TEST(HttpClient, get_request_with_custom_headers_for_existing_resource_succeeds)
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     // We finally execute the query synchronously and story the response.
     auto response = request->execute(default_progress_reporter);
@@ -183,7 +187,7 @@ TEST(HttpClient, get_request_with_custom_headers_for_existing_resource_succeeds)
     EXPECT_EQ(core::net::http::Status::ok, response.status);
 
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
 
     auto headers = root["headers"];
 
@@ -207,7 +211,9 @@ TEST(HttpClient, empty_header_values_are_handled_correctly)
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     // We finally execute the query synchronously and story the response.
     auto response = request->execute(default_progress_reporter);
@@ -216,7 +222,7 @@ TEST(HttpClient, empty_header_values_are_handled_correctly)
     EXPECT_EQ(core::net::http::Status::ok, response.status);
 
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
 
     auto headers = root["headers"];
     EXPECT_EQ(std::string{}, headers["Empty"].asString());
@@ -240,7 +246,9 @@ TEST(HttpClient, get_request_for_existing_resource_guarded_by_basic_auth_succeed
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     // We finally execute the query synchronously and story the response.
     auto response = request->execute(default_progress_reporter);
@@ -248,7 +256,7 @@ TEST(HttpClient, get_request_for_existing_resource_guarded_by_basic_auth_succeed
     // We expect the query to complete successfully
     EXPECT_EQ(core::net::http::Status::ok, response.status);
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     // We expect authentication to work.
     EXPECT_TRUE(root["authenticated"].asBool());
     // With the correct user id
@@ -274,7 +282,9 @@ TEST(HttpClient, DISABLED_get_request_for_existing_resource_guarded_by_digest_au
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     // We finally execute the query synchronously and story the response.
     auto response = request->execute(default_progress_reporter);
@@ -282,7 +292,7 @@ TEST(HttpClient, DISABLED_get_request_for_existing_resource_guarded_by_digest_au
     // We expect the query to complete successfully
     EXPECT_EQ(core::net::http::Status::ok, response.status);
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     // We expect authentication to work.
     EXPECT_TRUE(root["authenticated"].asBool());
     // With the correct user id
@@ -323,12 +333,14 @@ TEST(HttpClient, async_get_request_for_existing_resource_succeeds)
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     // We expect the query to complete successfully
     EXPECT_EQ(core::net::http::Status::ok, response.status);
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     // The url field of the payload should equal the original url we requested.
     EXPECT_EQ(url, root["url"].asString());
 
@@ -362,7 +374,9 @@ TEST(HttpClient, async_get_request_for_existing_resource_guarded_by_basic_authen
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     std::promise<core::net::http::Response> promise;
     auto future = promise.get_future();
@@ -392,7 +406,7 @@ TEST(HttpClient, async_get_request_for_existing_resource_guarded_by_basic_authen
     // We expect the query to complete successfully
     EXPECT_EQ(core::net::http::Status::ok, response.status);
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     // We expect authentication to work.
     EXPECT_TRUE(root["authenticated"].asBool());
     // With the correct user id
@@ -416,7 +430,9 @@ TEST(HttpClient, post_request_for_existing_resource_succeeds)
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     // We finally execute the query synchronously and story the response.
     auto response = request->execute(default_progress_reporter);
@@ -424,7 +440,7 @@ TEST(HttpClient, post_request_for_existing_resource_succeeds)
     // We expect the query to complete successfully
     EXPECT_EQ(core::net::http::Status::ok, response.status);
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     // The url field of the payload should equal the original url we requested.
     EXPECT_EQ(payload, root["data"].asString());
 }
@@ -451,10 +467,12 @@ TEST(HttpClient, post_form_request_for_existing_resource_succeeds)
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     EXPECT_EQ(core::net::http::Status::ok, response.status);
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     EXPECT_EQ("test", root["form"]["test"].asString());
 }
 
@@ -476,12 +494,14 @@ TEST(HttpClient, post_request_for_file_with_large_chunk_succeeds)
                                 size);
 
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     auto response = request->execute(default_progress_reporter);
 
     EXPECT_EQ(core::net::http::Status::ok, response.status);
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     EXPECT_EQ(url, root["url"].asString());
 }
 
@@ -498,12 +518,14 @@ TEST(HttpClient, put_request_for_existing_resource_succeeds)
                                value.size());
 
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     auto response = request->execute(default_progress_reporter);
 
     EXPECT_EQ(core::net::http::Status::ok, response.status);
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     EXPECT_EQ(payload.str(), root["data"].asString());
 }
 
@@ -525,12 +547,14 @@ TEST(HttpClient, put_request_for_file_with_large_chunk_succeeds)
                                size);
 
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     auto response = request->execute(default_progress_reporter);
 
     EXPECT_EQ(core::net::http::Status::ok, response.status);
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     EXPECT_EQ(url, root["url"].asString());
 }
 
@@ -542,12 +566,14 @@ TEST(HttpClient, del_request_for_existing_resource_succeeds)
     auto request = client->del(http::Request::Configuration::from_uri_as_string(url));
 
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     auto response = request->execute(default_progress_reporter);
 
     EXPECT_EQ(core::net::http::Status::ok, response.status);
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     EXPECT_EQ(url, root["url"].asString());
 }
 
@@ -615,7 +641,7 @@ const char* submit() { return "/v1/submit?key=net-cpp-testing"; }
 // for API and endpoint documentation.
 TEST(HttpClient, DISABLED_search_for_location_on_mozillas_location_service_succeeds)
 {
-    json::FastWriter writer;
+    json::StreamWriterBuilder wbuilder;
     json::Value search;
     json::Value cell;
     cell["radio"] = "umts";
@@ -642,16 +668,18 @@ TEST(HttpClient, DISABLED_search_for_location_on_mozillas_location_service_succe
             std::string(com::mozilla::services::location::host) +
             com::mozilla::services::location::resources::v1::search();
     auto request = client->post(http::Request::Configuration::from_uri_as_string(url),
-                                writer.write(search),
+                                json::writeString(wbuilder, search),
                                 http::ContentType::json);
 
     auto response = request->execute(default_progress_reporter);
 
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
     json::Value result;
+    std::string error;
 
     EXPECT_EQ(core::net::http::Status::ok, response.status);
-    EXPECT_TRUE(reader.parse(response.body, result));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &result, &error));
 
     // We cannot be sure that the server has got information for the given
     // cell and wifi ids. For that, we disable the test.
@@ -693,13 +721,13 @@ TEST(HttpClient, DISABLED_submit_of_location_on_mozillas_location_service_succee
 
     submit["items"].append(item);
 
-    json::FastWriter writer;
+    json::StreamWriterBuilder wbuilder;
     auto client = http::make_client();
     auto url =
             std::string(com::mozilla::services::location::host) +
             com::mozilla::services::location::resources::v1::submit();
     auto request = client->post(http::Request::Configuration::from_uri_as_string(url),
-                                writer.write(submit),
+                                json::writeString(wbuilder, submit),
                                 http::ContentType::json);
     auto response = request->execute(default_progress_reporter);
 

--- a/tests/http_streaming_client_test.cpp
+++ b/tests/http_streaming_client_test.cpp
@@ -156,7 +156,9 @@ TEST(StreamingHttpClient, get_request_for_existing_resource_succeeds)
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     // We finally execute the query synchronously and story the response.
     auto response = request->execute(default_progress_reporter, dh->to_data_handler());
@@ -164,7 +166,7 @@ TEST(StreamingHttpClient, get_request_for_existing_resource_succeeds)
     // We expect the query to complete successfully
     EXPECT_EQ(core::net::http::Status::ok, response.status);
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     // The url field of the payload should equal the original url we requested.
     EXPECT_EQ(url, root["url"].asString());
 }
@@ -191,7 +193,9 @@ TEST(StreamingHttpClient, get_request_with_custom_headers_for_existing_resource_
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     // We finally execute the query synchronously and story the response.
     auto response = request->execute(default_progress_reporter, dh->to_data_handler());
@@ -200,7 +204,7 @@ TEST(StreamingHttpClient, get_request_with_custom_headers_for_existing_resource_
     EXPECT_EQ(core::net::http::Status::ok, response.status);
 
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
 
     auto headers = root["headers"];
 
@@ -229,7 +233,9 @@ TEST(StreamingHttpClient, empty_header_values_are_handled_correctly)
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     // We finally execute the query synchronously and story the response.
     auto response = request->execute(default_progress_reporter, dh->to_data_handler());
@@ -238,7 +244,7 @@ TEST(StreamingHttpClient, empty_header_values_are_handled_correctly)
     EXPECT_EQ(core::net::http::Status::ok, response.status);
 
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
 
     auto headers = root["headers"];
     EXPECT_EQ(std::string{}, headers["Empty"].asString());
@@ -267,7 +273,9 @@ TEST(StreamingHttpClient, get_request_for_existing_resource_guarded_by_basic_aut
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     // We finally execute the query synchronously and story the response.
     auto response = request->execute(default_progress_reporter, dh->to_data_handler());
@@ -275,7 +283,7 @@ TEST(StreamingHttpClient, get_request_for_existing_resource_guarded_by_basic_aut
     // We expect the query to complete successfully
     EXPECT_EQ(core::net::http::Status::ok, response.status);
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     // We expect authentication to work.
     EXPECT_TRUE(root["authenticated"].asBool());
     // With the correct user id
@@ -306,7 +314,9 @@ TEST(StreamingHttpClient, DISABLED_get_request_for_existing_resource_guarded_by_
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     // We finally execute the query synchronously and story the response.
     auto response = request->execute(default_progress_reporter, dh->to_data_handler());
@@ -314,7 +324,7 @@ TEST(StreamingHttpClient, DISABLED_get_request_for_existing_resource_guarded_by_
     // We expect the query to complete successfully
     EXPECT_EQ(core::net::http::Status::ok, response.status);
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     // We expect authentication to work.
     EXPECT_TRUE(root["authenticated"].asBool());
     // With the correct user id
@@ -361,12 +371,14 @@ TEST(StreamingHttpClient, async_get_request_for_existing_resource_succeeds)
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     // We expect the query to complete successfully
     EXPECT_EQ(core::net::http::Status::ok, response.status);
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     // The url field of the payload should equal the original url we requested.
     EXPECT_EQ(url, root["url"].asString());
 
@@ -405,7 +417,9 @@ TEST(StreamingHttpClient, async_get_request_for_existing_resource_guarded_by_bas
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     std::promise<core::net::http::Response> promise;
     auto future = promise.get_future();
@@ -436,7 +450,7 @@ TEST(StreamingHttpClient, async_get_request_for_existing_resource_guarded_by_bas
     // We expect the query to complete successfully
     EXPECT_EQ(core::net::http::Status::ok, response.status);
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     // We expect authentication to work.
     EXPECT_TRUE(root["authenticated"].asBool());
     // With the correct user id
@@ -465,7 +479,9 @@ TEST(StreamingHttpClient, post_request_for_existing_resource_succeeds)
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     // We finally execute the query synchronously and story the response.
     auto response = request->execute(default_progress_reporter, dh->to_data_handler());
@@ -473,7 +489,7 @@ TEST(StreamingHttpClient, post_request_for_existing_resource_succeeds)
     // We expect the query to complete successfully
     EXPECT_EQ(core::net::http::Status::ok, response.status);
     // Parsing the body of the response as JSON should succeed.
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     // The url field of the payload should equal the original url we requested.
     EXPECT_EQ(payload, root["data"].asString());
 }
@@ -505,10 +521,12 @@ TEST(StreamingHttpClient, post_form_request_for_existing_resource_succeeds)
 
     // All endpoint data on httpbin.org is JSON encoded.
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     EXPECT_EQ(core::net::http::Status::ok, response.status);
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     EXPECT_EQ("test", root["form"]["test"].asString());
 }
 
@@ -536,10 +554,12 @@ TEST(StreamingHttpClient, post_request_for_file_with_large_chunk_succeeds)
     auto response = request->execute(default_progress_reporter, dh->to_data_handler());
   
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     EXPECT_EQ(core::net::http::Status::ok, response.status);
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     EXPECT_EQ(url, root["url"].asString());
 }
 
@@ -569,10 +589,12 @@ TEST(StreamingHttpClient, post_request_for_file_with_large_chunk_with_read_callb
     auto response = request->execute(default_progress_reporter, dh->to_data_handler());
   
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     EXPECT_EQ(core::net::http::Status::ok, response.status);
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     EXPECT_EQ(url, root["url"].asString());
 }
 
@@ -596,10 +618,12 @@ TEST(StreamingHttpClient, put_request_for_existing_resource_succeeds)
     auto response = request->execute(default_progress_reporter, dh->to_data_handler());
 
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
 
     EXPECT_EQ(core::net::http::Status::ok, response.status);
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     EXPECT_EQ(payload.str(), root["data"].asString());
 }
 
@@ -627,10 +651,12 @@ TEST(StreamingHttpClient, put_request_for_file_with_large_chunk_succeeds)
     auto response = request->execute(default_progress_reporter, dh->to_data_handler());
   
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
   
     EXPECT_EQ(core::net::http::Status::ok, response.status);
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     EXPECT_EQ(url, root["url"].asString());
 }
 
@@ -660,10 +686,12 @@ TEST(StreamingHttpClient, put_request_for_file_with_large_chunk_with_read_callba
     auto response = request->execute(default_progress_reporter, dh->to_data_handler());
   
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
   
     EXPECT_EQ(core::net::http::Status::ok, response.status);
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     EXPECT_EQ(url, root["url"].asString());
 }
 
@@ -682,10 +710,12 @@ TEST(StreamingHttpClient, del_request_for_existing_resource_succeeds)
     auto response = request->execute(default_progress_reporter, dh->to_data_handler());
 
     json::Value root;
-    json::Reader reader;
+    json::CharReaderBuilder b;
+    json::CharReader* reader(b.newCharReader());
+    std::string error;
   
     EXPECT_EQ(core::net::http::Status::ok, response.status);
-    EXPECT_TRUE(reader.parse(response.body, root));
+    EXPECT_TRUE(reader->parse(response.body.c_str(), response.body.c_str() + response.body.size(), &root, &error));
     EXPECT_EQ(url, root["url"].asString());
 }
 


### PR DESCRIPTION
Tested on Arch GNU/Linux

The package failed to build because `Json::Reader` and `Json::FastWriter` are [deprecated](http://open-source-parsers.github.io/jsoncpp-docs/doxygen/deprecated.html). This PR addresses that issue